### PR TITLE
Remove Faucet Server from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,3 @@
    $ cd sink
    $ cargo run -- <start_port> <end_port>
    ```
-	
- - Start the faucet server
-
-	```bash
-	$ cd faucet
-	$ cargo run -- <start_port> <end_port> <data_file> <packet_size>
-	```


### PR DESCRIPTION
Removes Faucet Server from readme as it was never pushed to github